### PR TITLE
Upgrade markupsafe to fix setuptools error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ idna==2.7
 imagesize==1.1.0
 jinja2==2.10.1
 markdown==3.0.1
-markupsafe==1.0
+markupsafe==1.1.1
 packaging==18.0
 pandoc==1.0.2
 pbr==5.1.0


### PR DESCRIPTION
Python 3.9
Virtualenv

Received this error trying to install dependencies in a local virtualenv created via pipenv:

> ImportError: cannot import name 'Feature' from 'setuptools'

Setuptools 46 introduced a breaking change and removed Feature support
https://github.com/pypa/setuptools/pull/1979

Fixed in https://github.com/pallets/markupsafe/pull/24