### PR TITLE
Clarify roles granted to the automation service account

### DIFF
--- a/docs/access-and-permissions/index.rst
+++ b/docs/access-and-permissions/index.rst
@@ -52,8 +52,13 @@ and require adjustments to use the least permissive model.
 Service Accounts
 ^^^^^^^^^^^^^^^^
 
-Rackspace adds a service account with the Project Owner role to each of
-your GCP projects that we manage: ``automation@rackspace-mgcp.iam.gserviceaccount.com``.
+Rackspace adds a primary service account with these roles to each of your GCP projects that we manage:
+
+- ``automation@rackspace-mgcp.iam.gserviceaccount.com``
+
+  + Project Browser
+  + Project Billing Manager
+  + Project IAM Admin
 
 Additionally, we grant these service accounts access with the following roles to enable support tooling for all Aviator and Service Blocks projects:
 


### PR DESCRIPTION
We no longer use the Project Owner role for the automation service account.